### PR TITLE
Fix docs links after org rename to quickwit-oss

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Let's create a directory in which your index will be stored.
 
 
 We will now initialize the index and create its schema.
-The [schema](https://tantivy-search.github.io/tantivy/tantivy/schema/index.html) defines
+The [schema](https://quickwit-oss.github.io/tantivy/tantivy/schema/index.html) defines
 the list of your fields, and for each field:
 - its name 
 - its type, currently `u64`, `i64` or `str`
 - how it should be indexed.
 
 You can find more information about the latter on 
-[tantivy's schema documentation page](https://tantivy-search.github.io/tantivy/tantivy/schema/index.html)
+[tantivy's schema documentation page](https://quickwit-oss.github.io/tantivy/tantivy/schema/index.html)
 
 In our case, our documents will contain
 * a title


### PR DESCRIPTION
Current links are 404