### PR TITLE
chore(build): bump traitobject to 0.1.1 to build against rust 1.87

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,9 +1576,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "traitobject"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+checksum = "04a79e25382e2e852e8da874249358d382ebaf259d0d34e75d8db16a7efabbc7"
 
 [[package]]
 name = "typeable"


### PR DESCRIPTION
bump traitobject to 0.1.1 to build against rust 1.87

```
   Compiling traitobject v0.1.0
error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Send + Sync + 'static)`
  --> /Users/rui/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/traitobject-0.1.0/src/impls.rs:72:1
   |
71 | unsafe impl Trait for ::std::marker::Send + Sync { }
   | ------------------------------------------------ first implementation here
72 | unsafe impl Trait for ::std::marker::Send + Send + Sync { }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`

error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Send + Sync + 'static)`
  --> /Users/rui/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/traitobject-0.1.0/src/impls.rs:73:1
   |
71 | unsafe impl Trait for ::std::marker::Send + Sync { }
   | ------------------------------------------------ first implementation here
72 | unsafe impl Trait for ::std::marker::Send + Send + Sync { }
73 | unsafe impl Trait for ::std::marker::Sync + Send { }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`

error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Send + Sync + 'static)`
  --> /Users/rui/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-1949cf8c6b5b557f/traitobject-0.1.0/src/impls.rs:75:1
   |
71 | unsafe impl Trait for ::std::marker::Send + Sync { }
   | ------------------------------------------------ first implementation here
...
75 | unsafe impl Trait for ::std::marker::Sync + Send + Sync { }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`

For more information about this error, try `rustc --explain E0119`.
error: could not compile `traitobject` (lib) due to 3 previous errors
```